### PR TITLE
fix unexpected clear key bindings when load_config()

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -39,12 +39,6 @@ Action::Action (const std::string &name, FcitxHotkey* hotkey, PMF pmf)
 {
 }
 
-Action::~Action (void)
-{
-    if (m_key_bindings)
-        FcitxHotkeyFree(m_key_bindings);
-}
-
 bool
 Action::perform (AnthyInstance *performer)
 {

--- a/src/action.h
+++ b/src/action.h
@@ -35,7 +35,6 @@ public:
 
     Action();
     Action  (const std::string &name, FcitxHotkey* hotkey, PMF pmf);
-    ~Action ();
 
 public:
     bool perform (AnthyInstance  *performer);


### PR DESCRIPTION
The destructor of Action class frees the memory of
(FcitxHotkey*)m_key_bindings by calling FcitxHotkeyFree().

m_key_bindings is same as the member of AnthyKeyProfile which is
AnthyInstance::m_config.m_key_default.

The members of m_key_defualt is allocated by FcitxConfigBindSync() in
AnthyInstance::load_config(), and it is passed to Action instance by
APPEND_ACTION() macro in AnthyInstance::configure().

However configure() is call AnthyInstance::m_actions.clear() before
APPEND_ACTION(). This is call destructor of Action class, then
m_key_bindings is freed by FcitxHotkeyFree(). The result of this, the
value of desc members of AnthyInstance::m_config.m_key_default is set to
NULL.

Because next AnthyInstance::save_coanfig() will treat all Hotkey of Key
group Null string, key bindings in fcitx-anthy.conf are cleared.

This commit prevent unexpexted call FcitxHotkeyFree() for
m_key_bindings. Instance of m_key_bindings is freed inside of
FcitxHotkeySet() routine, not needed to explicit free().

---

How to reproduce:

- Type A:
  1. enable fcitx-anthy
  2. save ~/.conf/fcitx/conf/fcitx-anthy.conf
  3. type "Ctrl-,", it's circler input mode
  4. check .conf/fcitx/conf/fcitx-anthy.conf
  5. compare conf files 2 and 4

- Type B:
  1. enable fcitx-anthy
  2. save ~/.conf/fcitx/conf/fcitx-anthy.conf
  3. configure KeyBindingProfile to Custom and LatinModeKey to MUHENKAN
  4. type "MUHENKAN" to change to Latin Mode from Kana Mode
  5. check .conf/fcitx/conf/fcitx-anthy.conf
  6. compare conf files 2 and 5
