### PR TITLE
    If Current State is IS_CLOSED, do not show inputWindow.

### DIFF
--- a/src/imengine.cpp
+++ b/src/imengine.cpp
@@ -821,6 +821,11 @@ AnthyInstance::install_properties (void)
 void
 AnthyInstance::set_input_mode (InputMode mode)
 {
+    //If Current State is IS_CLOSED, do nothing.
+    if (IS_CLOSED == FcitxInstanceGetCurrentState(get_owner())) {
+        return;
+    }
+
     if (mode >= FCITX_ANTHY_MODE_LAST)
         return;
     if (mode != get_input_mode ()) {

--- a/src/imengine.cpp
+++ b/src/imengine.cpp
@@ -821,7 +821,7 @@ AnthyInstance::install_properties (void)
 void
 AnthyInstance::set_input_mode (InputMode mode)
 {
-    //If Current State is IS_CLOSED, do nothing.
+    //If Current state is IS_CLOSED, do nothing.
     if (IS_CLOSED == FcitxInstanceGetCurrentState(get_owner())) {
         return;
     }


### PR DESCRIPTION
Hi, dear manager:

Here is my problem,  when I try to adjust the order of Input Method, a input window showed. like this:

![problem](https://user-images.githubusercontent.com/28881881/116645024-7e634680-a9a7-11eb-805b-c791ffe08ce8.png)

And finally I found it's fcitx-anthy caused this problem. So I  add some lines to avoid the problem.

I think these changes might help others as well.

best regards.